### PR TITLE
feat: added support for latest ingress version

### DIFF
--- a/identity-server-ingress.yaml
+++ b/identity-server-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wso2is-ingress
@@ -19,5 +19,8 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: wso2is-service
-          servicePort: 9443
+          service: 
+            name: wso2is-service
+            port: 
+              number: 9443
+        pathType: Prefix


### PR DESCRIPTION
Added support for the latest k8s version (1.26.x). 

According to official k8s docs at https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122, the `apiVersion` for ingress is now different. 

Otherwise, the ingress cannot be applied properly with the latest k8s.